### PR TITLE
Hint for "No devices -> no push notifications"

### DIFF
--- a/src/app/features/notification-settings.tsx
+++ b/src/app/features/notification-settings.tsx
@@ -88,17 +88,6 @@ export function NotificationSettings({
 			description={t("notifications.description")}
 		>
 			<div className="space-y-8">
-				<div className="space-y-4">
-					<h3 className="text-lg font-medium">
-						<T k="notifications.timing.heading" />
-					</h3>
-					<div className="space-y-4">
-						<TimezoneSection me={me} />
-						<NotificationTimeSection me={me} />
-						<LastDeliveredSection me={me} />
-					</div>
-				</div>
-
 				{/* Devices Section */}
 				<div className="space-y-4">
 					<h3 className="text-lg font-medium">
@@ -121,9 +110,20 @@ export function NotificationSettings({
 								</div>
 							</>
 						) : (
-							<p className="text-muted-foreground text-sm">
-								<T k="notifications.devices.noDevices.description" />
-							</p>
+							<>
+								<Alert>
+									<ExclamationTriangle />
+									<AlertTitle>
+										<T k="notifications.devices.noDevices.title" />
+									</AlertTitle>
+									<AlertDescription>
+										<T k="notifications.devices.noDevices.warning" />
+									</AlertDescription>
+								</Alert>
+								<p className="text-muted-foreground text-sm">
+									<T k="notifications.devices.noDevices.description" />
+								</p>
+							</>
 						)}
 					</div>
 
@@ -142,6 +142,17 @@ export function NotificationSettings({
 							</AlertDescription>
 						</Alert>
 					)}
+				</div>
+
+				<div className="space-y-4">
+					<h3 className="text-lg font-medium">
+						<T k="notifications.timing.heading" />
+					</h3>
+					<div className="space-y-4">
+						<TimezoneSection me={me} />
+						<NotificationTimeSection me={me} />
+						<LastDeliveredSection me={me} />
+					</div>
 				</div>
 			</div>
 		</SettingsSection>

--- a/src/shared/intl/messages.settings.ts
+++ b/src/shared/intl/messages.settings.ts
@@ -213,6 +213,9 @@ const baseSettingsMessages = messages({
 		"Manage devices registered for push notifications.",
 	"notifications.devices.noDevices.description":
 		"Add devices to receive push notifications.",
+	"notifications.devices.noDevices.title": "No Devices Added",
+	"notifications.devices.noDevices.warning":
+		"You will NOT receive any notifications until you add at least one device. Add this device to start receiving reminders.",
 	"notifications.devices.thisDevice": "This device",
 	"notifications.devices.actions.title": "Device Actions",
 	"notifications.devices.actions.description":
@@ -547,6 +550,9 @@ const deSettingsMessages = translate(baseSettingsMessages, {
 		"Geräte verwalten, die Push-Benachrichtigungen empfangen.",
 	"notifications.devices.noDevices.description":
 		"Füge Geräte hinzu, die Push-Benachrichtigungen erhalten.",
+	"notifications.devices.noDevices.title": "Keine Geräte hinzugefügt",
+	"notifications.devices.noDevices.warning":
+		"Du wirst KEINE Benachrichtigungen erhalten, bis du mindestens ein Gerät hinzufügst. Füge dieses Gerät hinzu, um Erinnerungen zu erhalten.",
 	"notifications.devices.thisDevice": "Dieses Gerät",
 	"notifications.devices.actions.title": "Geräteaktionen",
 	"notifications.devices.actions.description":


### PR DESCRIPTION
fixes #21 

user feedback led to the conclusion that it's not clear that they won't receive notifications unless they add a device.
this PR adds a hint and moves the devices subsection above the notification timing